### PR TITLE
add non-breaking optional deployment targets and readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,59 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 ```
+
+## Targets
+
+Optional `input` to specify a deployment target. Handy for Hugo sites that have multiple environments (e.g. "staging" and "production").
+
+If `target` is not specified in your GitHub Action, the first deployment target is used by default.
+
+### Example
+
+#### GitHub Action
+
+```
+name: Hugo Build and Deploy to S3
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out master
+        uses: actions/checkout@master
+      
+      - name: Build and deploy
+        uses: AlbertMorenoDEV/deploy-hugo-to-s3-action@v0.0.3
+        with:
+          hugo-version: 0.85.0
+          target: production
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+```
+
+#### Hugo Config
+
+```
+baseURL: /
+languageCode: en-us
+title: Example Site
+
+# -------------- AWS S3 Deployment Configs -------------- #
+
+deployment:
+
+  targets:
+    - name: "staging"
+      URL: "s3://stg.example.com?region=us-east-2"
+
+    - name: "production"
+      URL: "s3://example.com?region=us-east-1"
+
+```

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
   hugo-version:
     description: 'Choose a valid Hugo version'
     required: true
+  target:
+    description: 'A deployment target'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -30,7 +34,12 @@ runs:
       shell: bash
     
     - id: deploy-to-s3
-      run: $HOME/hugo -v deploy --invalidateCDN --maxDeletes -1
+      run: |
+        if [[ "${{ inputs.target }}" ]]; then
+          $HOME/hugo -v deploy --target=${{ inputs.target }} --invalidateCDN --maxDeletes -1
+        else
+          $HOME/hugo -v deploy --invalidateCDN --maxDeletes -1
+        fi
       env:
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}


### PR DESCRIPTION
* adds an `input` for deployment `target` that will work with Hugo's `deployment` config
* updates README with example