### PR TITLE
feat: add skip-deployment input to allow a build-only run

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,11 @@ inputs:
   environment:
     description: 'environment'
     required: false
-    default: ''    
+    default: ''
+  skip-deployment:
+    description: 'Skip deployment to AWS'
+    required: false
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -48,6 +52,7 @@ runs:
       shell: bash
     
     - id: deploy-to-s3
+      if: inputs.skip-deployment == 'false'
       run: |
         HUGO_FLAGS=" --invalidateCDN --maxDeletes -1"
         


### PR DESCRIPTION
This modification allows a user to set an input variable, `skip-deployment`, to perform a build but not a deploy.

I raised this change as I find that this behavior would be helpful in performing a "dry run" of Hugo as part of a pull request workflow, ensuring that the build succeeds before the site gets deployed to its downstream.