### PR TITLE
chore: update flags for deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Check out master
         uses: actions/checkout@master
-      
+
       - name: Build and deploy
         uses: AlbertMorenoDEV/deploy-hugo-to-s3-action@v0.0.5
         with:
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Check out master
         uses: actions/checkout@master
-      
+
       - name: Build and deploy
         uses: AlbertMorenoDEV/deploy-hugo-to-s3-action@v0.0.5
         with:
@@ -97,7 +97,7 @@ jobs:
     steps:
       - name: Check out master
         uses: actions/checkout@master
-      
+
       - name: Build and deploy
         uses: AlbertMorenoDEV/deploy-hugo-to-s3-action@v0.0.5
         with:

--- a/README.md
+++ b/README.md
@@ -4,14 +4,17 @@ This GitHub action makes it easy to build and deploy any Hugo static website to 
 
 ## Example
 
-```
+```yaml
+---
 name: Hugo Build and Deploy to S3
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
 
 jobs:
   build:
@@ -24,7 +27,7 @@ jobs:
       - name: Build and deploy
         uses: AlbertMorenoDEV/deploy-hugo-to-s3-action@v0.0.5
         with:
-          hugo-version: 0.89.0
+          hugo-version: 0.134.3
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 ```
@@ -37,14 +40,17 @@ Optional `config` to specify a custom config file. Handy for Hugo sites that hav
 
 #### GitHub Action
 
-```
+```yaml
+---
 name: Hugo Build and Deploy to S3
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
 
 jobs:
   build:
@@ -57,7 +63,7 @@ jobs:
       - name: Build and deploy
         uses: AlbertMorenoDEV/deploy-hugo-to-s3-action@v0.0.5
         with:
-          hugo-version: 0.89.0
+          hugo-version: 0.134.3
           config: path/config.toml
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -73,14 +79,16 @@ If `target` is not specified in your GitHub Action, the first deployment target 
 
 #### GitHub Action
 
-```
+```yaml
 name: Hugo Build and Deploy to S3
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
 
 jobs:
   build:
@@ -93,7 +101,7 @@ jobs:
       - name: Build and deploy
         uses: AlbertMorenoDEV/deploy-hugo-to-s3-action@v0.0.5
         with:
-          hugo-version: 0.89.0
+          hugo-version: 0.134.3
           target: production
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -101,7 +109,8 @@ jobs:
 
 #### Hugo Config
 
-```
+```yaml
+---
 baseURL: /
 languageCode: en-us
 title: Example Site
@@ -109,12 +118,9 @@ title: Example Site
 # -------------- AWS S3 Deployment Configs -------------- #
 
 deployment:
-
   targets:
     - name: "staging"
       URL: "s3://stg.example.com?region=us-east-2"
-
     - name: "production"
       URL: "s3://example.com?region=us-east-1"
-
 ```

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,11 @@ inputs:
   environment:
     description: 'environment'
     required: false
-    default: ''    
+    default: ''
+  skip-deployment:
+    description: 'Skip deployment to AWS'
+    required: false
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -48,6 +52,7 @@ runs:
       shell: bash
     
     - id: deploy-to-s3
+      if: inputs.skip-deployment == 'false'
       run: |
         HUGO_FLAGS=" --invalidateCDN --maxDeletes -1"
         

--- a/action.yml
+++ b/action.yml
@@ -1,35 +1,35 @@
-name: 'Deploy Hugo to S3'
-description: 'Build and deploy Hugo static websites to AWS S3'
-author: 'AlbertMorenoDEV'
+name: "Deploy Hugo to S3"
+description: "Build and deploy Hugo static websites to AWS S3"
+author: "AlbertMorenoDEV"
 branding:
   icon: package
   color: yellow
 inputs:
   hugo-version:
-    description: 'Choose a valid Hugo version'
+    description: "Choose a valid Hugo version"
     required: true
   aws-access-key-id:
-    description: 'AWS Access Key ID'
+    description: "AWS Access Key ID"
     required: true
   aws-secret-access-key:
-    description: 'AWS Secret Access Key'
+    description: "AWS Secret Access Key"
     required: true
   target:
-    description: 'A deployment target'
+    description: "A deployment target"
     required: false
-    default: ''
+    default: ""
   config:
-    description: 'Config file'
+    description: "Config file"
     required: false
-    default: ''
+    default: ""
   environment:
-    description: 'environment'
+    description: "environment"
     required: false
-    default: ''
+    default: ""
   skip-deployment:
-    description: 'Skip deployment to AWS'
+    description: "Skip deployment to AWS"
     required: false
-    default: 'false'
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -40,35 +40,35 @@ runs:
         tar xvzf ${HUGO_DOWNLOAD} hugo
         mv hugo $HOME/hugo
       shell: bash
-    
+
     - id: download-themes
       run: |
         git submodule init
         git submodule update
       shell: bash
-    
+
     - id: hugo-build
-      run: $HOME/hugo -v
+      run: $HOME/hugo
       shell: bash
-    
+
     - id: deploy-to-s3
       if: inputs.skip-deployment == 'false'
       run: |
-        HUGO_FLAGS=" --invalidateCDN --maxDeletes -1"
-        
+        HUGO_FLAGS=" --logLevel info --invalidateCDN --maxDeletes -1"
+
         if [[ "${{ inputs.environment }}" ]]; then
           HUGO_FLAGS="$HUGO_FLAGS --environment=${{ inputs.environment }}"
-        fi        
-        
+        fi
+
         if [[ "${{ inputs.config }}" ]]; then
           HUGO_FLAGS="$HUGO_FLAGS --config=${{ inputs.config }}"
         fi
-        
+
         if [[ "${{ inputs.target }}" ]]; then
           HUGO_FLAGS="$HUGO_FLAGS --target=${{ inputs.target }}"
         fi
 
-        $HOME/hugo -v deploy $HUGO_FLAGS
+        $HOME/hugo deploy $HUGO_FLAGS
       env:
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}


### PR DESCRIPTION
```plaintext
ERROR deprecated: --verbose was deprecated in Hugo v0.114.0 and will be removed in Hugo 0.135.0. use --logLevel info
```

Since Hugo v0.114.0, hugo raises an `ERROR` due to the hardcoded `-v` flag. This PR changes to a differently hardcoded value of `--logLevel info`, more appropriate for current versions of Hugo.

Also, this cleans up some of the YAML within the examples of the README, generated by running [Prettier](https://prettier.io/) against the repository.